### PR TITLE
Update api.rst

### DIFF
--- a/Nightscout/EN/Technical info/api.rst
+++ b/Nightscout/EN/Technical info/api.rst
@@ -17,7 +17,7 @@ Example Queries
 -  Boluses over 2U: ``http://localhost:1337/api/v1/treatments.json?find[insulin][$gte]=2``
 
 The API is Swagger enabled, so you can generate client code to make working with the API easy. To learn more about the Nightscout API, visit
-https://YOUR-SITE.com/api-docs.html or review `swagger.yaml <https://github.com/nightscout/cgm-remote-monitor/blob/master/swagger.yaml>`__.
+https://YOUR-SITE.com/api-docs/ or review `swagger.yaml <https://github.com/nightscout/cgm-remote-monitor/blob/master/swagger.yaml>`__.
 
 ----------
 


### PR DESCRIPTION
`/api-docs.html` doesn't appear to work on NightScout versions 14.2.2 or 14.2.3. using `/api-docs/` works as expected