### PR TITLE
Update api.rst to reflect current API Docs locations

### DIFF
--- a/Nightscout/EN/Technical info/api.rst
+++ b/Nightscout/EN/Technical info/api.rst
@@ -17,7 +17,7 @@ Example Queries
 -  Boluses over 2U: ``http://localhost:1337/api/v1/treatments.json?find[insulin][$gte]=2``
 
 The API is Swagger enabled, so you can generate client code to make working with the API easy. To learn more about the Nightscout API, visit
-https://YOUR-SITE.com/api-docs.html or review `swagger.yaml <https://github.com/nightscout/cgm-remote-monitor/blob/master/swagger.yaml>`__.
+https://YOUR-SITE.com/api-docs or review `swagger.yaml <https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/server/swagger.yaml>`__.
 
 ----------
 


### PR DESCRIPTION
I noticed that the two locations for the Swagger API docs weren't working for me. The documentation in the api.rst doc refers to https://YOUR-SITE.com/api-docs.html, which gives me 404, while https://YOUR-SITE.com/api-docs works. The swagger.yaml file also seems to have moved, so also updated that.